### PR TITLE
Declare _bc_tick_counter as volatile

### DIFF
--- a/bcl/src/bc_tick.c
+++ b/bcl/src/bc_tick.c
@@ -2,7 +2,7 @@
 #include <bc_irq.h>
 #include <stm32l0xx.h>
 
-static bc_tick_t _bc_tick_counter = 0;
+static volatile bc_tick_t _bc_tick_counter = 0;
 
 bc_tick_t bc_tick_get(void)
 {


### PR DESCRIPTION
Since the variable is updated from an interrupt handler, better be
safe than sorry and declare it as volatile to prevent the compiler
from optimizing away reads from the variable's memory location.