### PR TITLE
Make scheduler interval compile-time configurable

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -120,6 +120,11 @@ CFLAGS_RELEASE += -D'RELEASE'
 BAND ?= 868
 CFLAGS += -D'BAND=$(BAND)'
 
+SCHEDULER_INTERVAL ?=
+ifneq ($(SCHEDULER_INTERVAL),)
+  CFLAGS += -D'BC_SCHEDULER_INTERVAL_MS=$(SCHEDULER_INTERVAL)'
+endif
+
 ################################################################################
 # Compiler flags for "s" files                                                 #
 ################################################################################

--- a/bcl/inc/bc_scheduler.h
+++ b/bcl/inc/bc_scheduler.h
@@ -13,6 +13,10 @@
 #define BC_SCHEDULER_MAX_TASKS 32
 #endif
 
+#ifndef BC_SCHEDULER_INTERVAL_MS
+#define BC_SCHEDULER_INTERVAL_MS 10
+#endif
+
 //! @brief Task ID assigned by scheduler
 
 typedef size_t bc_scheduler_task_id_t;

--- a/bcl/src/bc_system.c
+++ b/bcl/src/bc_system.c
@@ -4,6 +4,7 @@
 #include <bc_i2c.h>
 #include <bc_timer.h>
 #include <stm32l0xx.h>
+#include <stm32l0xx_hal_conf.h>
 
 #define _BC_SYSTEM_DEBUG_ENABLE 0
 
@@ -244,8 +245,8 @@ static void _bc_system_init_rtc(void)
         continue;
     }
 
-    // Set wake-up auto-reload value
-    RTC->WUTR = 20;
+    // Set wake-up auto-reload value based on the configured scheduler interval.
+    RTC->WUTR = LSE_VALUE / 16 * BC_SCHEDULER_INTERVAL_MS / 1000;
 
     // Clear timer flag
     RTC->ISR &= ~RTC_ISR_WUTF;
@@ -522,7 +523,7 @@ void RTC_IRQHandler(void)
         // Clear wake-up timer flag
         RTC->ISR &= ~RTC_ISR_WUTF;
 
-        bc_tick_increment_irq(10);
+        bc_tick_increment_irq(BC_SCHEDULER_INTERVAL_MS);
     }
 
     // Clear EXTI interrupt flag


### PR DESCRIPTION
Automatically calculate the reload value for the RTC wake up timer to
make it easier for the developer to re-configure the interval at which
the core will be woken up and the scheduler run. The default value of
10 milliseconds can be overriden with the BC_SCHEDULER_INTERVAL_MS
macro defined in bc_scheduler.h.

A scheduler interval can also be provided on the make command line as
follows:

make SCHEDULER_INTERVAL=100 debug

Make sure to run make clean before you change the scheduler interval
value on the command line.