### PR TITLE
Provide application_idle hook to application developers

### DIFF
--- a/bcl/inc/bc_sleep.h
+++ b/bcl/inc/bc_sleep.h
@@ -1,0 +1,46 @@
+#ifndef _BC_SLEEP_H
+#define _BC_SLEEP_H
+
+#include <bc_system.h>
+
+typedef struct bc_sleep_manager {
+    int disable_sleep;
+} bc_sleep_manager_t;
+
+extern bc_sleep_manager_t sleep_manager;
+
+/**
+ * Prevent the processor from sleeping
+ *
+ * The function sets an internal flag that will prevent the process core from
+ * entering low power (sleep) modes. If called repeatedly, bc_sleep_enable must
+ * be called repeatedly also to re-enable sleep modes.
+ */
+void bc_sleep_disable(void);
+
+/**
+ * Allow the processor to enter low power modes when idle
+ *
+ * Call this function after calling bc_sleep_disable to re-enable low power
+ * (sleep) process modes. Must be called repeatedly if bc_sleep_disable was
+ * called repeatedly to enable sleeping.
+ */
+void bc_sleep_enable(void);
+
+/**
+ * Put the processor to low power mode (unless disabled)
+ *
+ * Transition the processor core to a low power mode in the absence of work to
+ * do, unless sleeping has been disabled with bc_sleep_disable. The function
+ * returns immediately if sleeping has been disabled by the application.
+ *
+ * Sleeping is enabled by default (upon application startup).
+ */
+static inline void bc_sleep(void)
+{
+    if (sleep_manager.disable_sleep == 0) {
+        bc_system_sleep();
+    }
+}
+
+#endif /* _BC_SLEEP_H */

--- a/bcl/src/bc_adc.c
+++ b/bcl/src/bc_adc.c
@@ -2,6 +2,7 @@
 #include <bc_scheduler.h>
 #include <bc_irq.h>
 #include <stm32l083xx.h>
+#include <bc_sleep.h>
 
 #include <bc_system.h>
 
@@ -336,7 +337,7 @@ void ADC1_COMP_IRQHandler(void)
         // Disable all ADC interrupts
         ADC1->IER = 0;
 
-        bc_scheduler_enable_sleep();
+        bc_sleep_enable();
     }
 }
 

--- a/bcl/src/bc_scheduler.c
+++ b/bcl/src/bc_scheduler.c
@@ -1,6 +1,7 @@
 #include <bc_scheduler.h>
 #include <bc_system.h>
 #include <bc_error.h>
+#include <main.h>
 
 static struct
 {
@@ -15,7 +16,6 @@ static struct
     bc_tick_t tick_spin;
     bc_scheduler_task_id_t current_task_id;
     bc_scheduler_task_id_t max_task_id;
-    int sleep_bypass_semaphore;
 
 } _bc_scheduler;
 
@@ -46,10 +46,7 @@ void bc_scheduler_run(void)
                 }
             }
         }
-        if (_bc_scheduler.sleep_bypass_semaphore == 0)
-        {
-            bc_system_sleep();
-        }
+        application_idle();
     }
 }
 
@@ -104,16 +101,6 @@ bc_scheduler_task_id_t bc_scheduler_get_current_task_id(void)
 bc_tick_t bc_scheduler_get_spin_tick(void)
 {
     return _bc_scheduler.tick_spin;
-}
-
-void bc_scheduler_disable_sleep(void)
-{
-    _bc_scheduler.sleep_bypass_semaphore++;
-}
-
-void bc_scheduler_enable_sleep(void)
-{
-    _bc_scheduler.sleep_bypass_semaphore--;
 }
 
 void bc_scheduler_plan_now(bc_scheduler_task_id_t task_id)

--- a/bcl/src/bc_sleep.c
+++ b/bcl/src/bc_sleep.c
@@ -1,0 +1,16 @@
+#include <bc_sleep.h>
+#include <bc_system.h>
+
+bc_sleep_manager_t sleep_manager = {
+    .disable_sleep = 0
+};
+
+void bc_sleep_disable(void)
+{
+    sleep_manager.disable_sleep++;
+}
+
+void bc_sleep_enable(void)
+{
+    sleep_manager.disable_sleep--;
+}

--- a/bcl/src/bc_system.c
+++ b/bcl/src/bc_system.c
@@ -5,6 +5,7 @@
 #include <bc_timer.h>
 #include <stm32l0xx.h>
 #include <stm32l0xx_hal_conf.h>
+#include <bc_sleep.h>
 
 #define _BC_SYSTEM_DEBUG_ENABLE 0
 
@@ -387,7 +388,7 @@ void bc_system_hsi16_enable(void)
         SystemCoreClock = 16000000;
     }
 
-    bc_scheduler_disable_sleep();
+    bc_sleep_disable();
 }
 
 void bc_system_hsi16_disable(void)
@@ -417,7 +418,7 @@ void bc_system_hsi16_disable(void)
         PWR->CR |= PWR_CR_VOS;
     }
 
-    bc_scheduler_enable_sleep();
+    bc_sleep_enable();
 }
 
 void bc_system_pll_enable(void)

--- a/bcl/stm/inc/main.h
+++ b/bcl/stm/inc/main.h
@@ -1,4 +1,6 @@
 #ifndef _MAIN_H
 #define _MAIN_H
 
+void application_idle();
+
 #endif // _MAIN_H

--- a/bcl/stm/src/main.c
+++ b/bcl/stm/src/main.c
@@ -4,6 +4,7 @@
 #include <bc_log.h>
 #include <bc_led.h>
 #include <bc_timer.h>
+#include <bc_sleep.h>
 
 void application_init(void);
 
@@ -36,6 +37,11 @@ __attribute__((weak)) void application_init(void)
 __attribute__((weak)) void application_task(void *param)
 {
     (void) param;
+}
+
+__attribute__((weak)) void application_idle()
+{
+    bc_sleep();
 }
 
 __attribute__((weak)) void application_error(bc_error_t code)


### PR DESCRIPTION
In my own application, I would like to be able to customize the steps taken by the system when entering a low power mode without the need to modify the SDK source code. I propose to add the weak symbol application_idle that could be overridden by the application developer. Function application_idle will be invoked by the scheduler once it has processed all pending tasks.

To be able to implement this, I also needed to decouple the scheduler from sleep related code. I propose to create a new global sleep manager object that could be used to control the various aspects of configuring and entering low power modes. For now, the object is very rudimentary, but can be incrementally improved.